### PR TITLE
fix: remove deprecated flag includeForks in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-      "github>DanySK/renovate-config"
-    ],
-    "includeForks": true
-  }
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>Collektive/renovate-config:kotlin"
+  ]
+}


### PR DESCRIPTION
fix: remove deprecated flag includeForks in renovate.json