### PR TITLE
feat: implement MIT-Proto temperature field demo

### DIFF
--- a/effects/temperature.json
+++ b/effects/temperature.json
@@ -46,14 +46,14 @@
       "val": 0
     },
     "minprop": {
-      "max": 10,
-      "min": -10,
-      "val": 0
+      "max": 50,
+      "min": 0,
+      "val": 20
     },
     "maxprop": {
-      "max": 10,
-      "min": -10,
-      "val": 10
+      "max": 50,
+      "min": 0,
+      "val": 30
     },
     "colorCache": {
       "value": -16777216
@@ -178,49 +178,5 @@
     "colorCache": {
       "value": -65536
     }
-  },
-  {
-    "type": "class it.unibo.alchemist.boundary.gui.effects.DrawBidimensionalGaussianLayersGradient",
-    "samples": {
-      "max": 400,
-      "min": 10,
-      "val": 100
-    },
-    "minLayerValue": "0.0",
-    "maxLayerValue": "0.0",
-    "minLayerValueCached": "0.0",
-    "maxLayerValueCached": "0.0",
-    "minLayerValueDouble": 0.0,
-    "maxLayerValueDouble": 0.0,
-    "mapper": {
-      "type": "class it.unibo.alchemist.boundary.gui.effects.BidimensionalGaussianLayersMapper",
-      "minAndMaxToBeSet": true
-    },
-    "layerFilter": false,
-    "molString": "",
-    "alpha": {
-      "max": 255,
-      "min": 0,
-      "val": 127
-    },
-    "red": {
-      "max": 255,
-      "min": 0,
-      "val": 0
-    },
-    "green": {
-      "max": 255,
-      "min": 0,
-      "val": 0
-    },
-    "blue": {
-      "max": 255,
-      "min": 0,
-      "val": 255
-    },
-    "colorCache": {
-      "value": 2130706687
-    },
-    "markerNodeID": 256
   }
 ]

--- a/simulation/src/main/kotlin/it/unibo/collektive/examples/temperature/Temperature.kt
+++ b/simulation/src/main/kotlin/it/unibo/collektive/examples/temperature/Temperature.kt
@@ -6,8 +6,8 @@ import it.unibo.collektive.aggregate.values
 import it.unibo.collektive.alchemist.device.sensors.EnvironmentVariables
 
 private const val HEAT_SOURCE_TEMPERATURE = 30.0
-private const val COLD_SOURCE_TEMPERATURE = -20.0
-private const val INITIAL_TEMPERATURE = 0.0
+private const val COLD_SOURCE_TEMPERATURE = 20.0
+private const val INITIAL_TEMPERATURE = 25.0
 
 /**
  * Entry point for the program which computes the temperature's field.
@@ -16,8 +16,9 @@ fun Aggregate<Int>.temperatureEntrypoint(env: EnvironmentVariables): Double =
     temperature(env["heat_source"], env["cold_source"])
 
 /**
- * Represents an evolving temperature field where each device updates its temperature over time.
- * Some devices act as fixed heat sources at 30°C, others as fixed cold sources at -20°C.
+ * Represents an evolving pseudo-temperature field where each device updates its temperature over time.
+ * Some devices act as fixed heat sources ([heatSource]) at [HEAT_SOURCE_TEMPERATURE]°C,
+ * others as fixed cold sources ([coldSource]) at [COLD_SOURCE_TEMPERATURE]°C.
  * All other devices calculate their temperature dynamically as the average temperature of their neighboring devices.
  */
 fun Aggregate<Int>.temperature(heatSource: Boolean, coldSource: Boolean): Double =

--- a/simulation/src/main/yaml/temperature.yml
+++ b/simulation/src/main/yaml/temperature.yml
@@ -4,16 +4,27 @@ network-model:
   type: ConnectWithinDistance
   parameters: [ 20 ]
 
-_pool: &program
-  - time-distribution: 1
-    type: Event
-    actions:
-      - type: RunCollektiveProgram
-        parameters: [ it.unibo.collektive.examples.temperature.TemperatureKt.temperatureEntrypoint ]
+_anchors:
+  program: &program
+    - time-distribution: 1
+      type: Event
+      actions:
+        - type: RunCollektiveProgram
+          parameters: [ it.unibo.collektive.examples.temperature.TemperatureKt.temperatureEntrypoint ]
+  heat_source_content: &heat_source_content
+    - molecule: heat_source
+      concentration: true
+    - molecule: cold_source
+      concentration: false
+  cold_source_content: &cold_source_content
+    - molecule: cold_source
+      concentration: true
+    - molecule: heat_source
+      concentration: false
 
 deployments:
   - type: Grid
-    parameters: [ 0, 0, 200, 200, 10, 10, 20, 20 ]
+    parameters: [ 0, 0, 200, 200, 10, 10, 10, 10 ]
     programs:
       - *program
     contents:
@@ -24,47 +35,25 @@ deployments:
 
   - type: Point
     parameters: [ 100, 100 ]
-    programs:
-      - *program
-    contents:
-      - molecule: heat_source
-        concentration: true
-      - molecule: cold_source
-        concentration: false
-
+    programs: [ *program ]
+    contents: *heat_source_content
+  - type: Point
+    parameters: [ 50, 100 ]
+    programs: [ *program ]
+    contents: *heat_source_content
   - type: Point
     parameters: [ 0, 0 ]
-    programs:
-      - *program
-    contents:
-      - molecule: cold_source
-        concentration: true
-      - molecule: heat_source
-        concentration: false
+    programs: [ *program ]
+    contents: *cold_source_content
   - type: Point
     parameters: [ 200, 0 ]
-    programs:
-      - *program
-    contents:
-      - molecule: cold_source
-        concentration: true
-      - molecule: heat_source
-        concentration: false
+    programs: [ *program ]
+    contents: *cold_source_content
   - type: Point
     parameters: [ 0, 200 ]
-    programs:
-      - *program
-    contents:
-      - molecule: cold_source
-        concentration: true
-      - molecule: heat_source
-        concentration: false
+    programs: [ *program ]
+    contents: *cold_source_content
   - type: Point
     parameters: [ 200, 200 ]
-    programs:
-      - *program
-    contents:
-      - molecule: cold_source
-        concentration: true
-      - molecule: heat_source
-        concentration: false
+    programs: [ *program ]
+    contents: *cold_source_content


### PR DESCRIPTION
The implementation is based on the `temperature.proto` demo from the MIT-Proto project.
The goal is to represent an evolving pseudo-temperature field where each device updates its temperature over time.
The only difference lies in how it is decided whether a device is a heat or cold source: here, this is determined by the simulation environment.

**Related to:**
*   Original Proto demo: https://github.com/jakebeal/MIT-Proto/blob/master/proto/demos/temperature.proto