### PR TITLE
feat: implement MIT-Proto in-circle demo 

### DIFF
--- a/effects/inCircle.json
+++ b/effects/inCircle.json
@@ -1,0 +1,182 @@
+[
+  {
+    "type": "class it.unibo.alchemist.boundary.gui.effects.DrawShape",
+    "curIncarnation": "collektive",
+    "mode": "FILL_ELLIPSE",
+    "red": {
+      "max": 255,
+      "min": 0,
+      "val": 0
+    },
+    "blue": {
+      "max": 255,
+      "min": 0,
+      "val": 0
+    },
+    "green": {
+      "max": 255,
+      "min": 0,
+      "val": 0
+    },
+    "alpha": {
+      "max": 255,
+      "min": 0,
+      "val": 255
+    },
+    "scaleFactor": {
+      "max": 100,
+      "min": 0,
+      "val": 50
+    },
+    "size": {
+      "max": 100,
+      "min": 0,
+      "val": 5
+    },
+    "molFilter": false,
+    "molString": "",
+    "molPropertyFilter": false,
+    "property": "",
+    "writingPropertyValue": false,
+    "c": "ALPHA",
+    "reverse": false,
+    "propoom": {
+      "max": 10,
+      "min": -10,
+      "val": 0
+    },
+    "minprop": {
+      "max": 10,
+      "min": -10,
+      "val": 0
+    },
+    "maxprop": {
+      "max": 10,
+      "min": -10,
+      "val": 10
+    },
+    "colorCache": {
+      "value": -16777216
+    }
+  },
+  {
+    "type": "class it.unibo.alchemist.boundary.gui.effects.DrawShape",
+    "curIncarnation": "collektive",
+    "mode": "FILL_ELLIPSE",
+    "red": {
+      "max": 255,
+      "min": 0,
+      "val": 255
+    },
+    "blue": {
+      "max": 255,
+      "min": 0,
+      "val": 0
+    },
+    "green": {
+      "max": 255,
+      "min": 0,
+      "val": 0
+    },
+    "alpha": {
+      "max": 255,
+      "min": 0,
+      "val": 255
+    },
+    "scaleFactor": {
+      "max": 100,
+      "min": 0,
+      "val": 50
+    },
+    "size": {
+      "max": 100,
+      "min": 0,
+      "val": 14
+    },
+    "molFilter": false,
+    "molString": "it.unibo.collektive.examples.inCircle.InCircleKt.inCircleEntrypoint",
+    "molPropertyFilter": true,
+    "property": "",
+    "writingPropertyValue": false,
+    "c": "ALPHA",
+    "reverse": false,
+    "propoom": {
+      "max": 10,
+      "min": -10,
+      "val": 0
+    },
+    "minprop": {
+      "max": 10,
+      "min": -10,
+      "val": 0
+    },
+    "maxprop": {
+      "max": 10,
+      "min": -10,
+      "val": 1
+    },
+    "colorCache": {
+      "value": -65536
+    }
+  },
+  {
+    "type": "class it.unibo.alchemist.boundary.gui.effects.DrawShape",
+    "curIncarnation": "collektive",
+    "mode": "FILL_ELLIPSE",
+    "red": {
+      "max": 255,
+      "min": 0,
+      "val": 0
+    },
+    "blue": {
+      "max": 255,
+      "min": 0,
+      "val": 0
+    },
+    "green": {
+      "max": 255,
+      "min": 0,
+      "val": 255
+    },
+    "alpha": {
+      "max": 255,
+      "min": 0,
+      "val": 255
+    },
+    "scaleFactor": {
+      "max": 100,
+      "min": 0,
+      "val": 50
+    },
+    "size": {
+      "max": 100,
+      "min": 0,
+      "val": 17
+    },
+    "molFilter": false,
+    "molString": "center",
+    "molPropertyFilter": true,
+    "property": "",
+    "writingPropertyValue": false,
+    "c": "ALPHA",
+    "reverse": false,
+    "propoom": {
+      "max": 10,
+      "min": -10,
+      "val": 0
+    },
+    "minprop": {
+      "max": 10,
+      "min": -10,
+      "val": 0
+    },
+    "maxprop": {
+      "max": 10,
+      "min": -10,
+      "val": 1
+    },
+    "colorCache": {
+      "value": -16711936
+    }
+  }
+]

--- a/simulation/src/main/kotlin/it/unibo/collektive/examples/inCircle/InCircle.kt
+++ b/simulation/src/main/kotlin/it/unibo/collektive/examples/inCircle/InCircle.kt
@@ -5,39 +5,35 @@ import it.unibo.alchemist.model.Position
 import it.unibo.collektive.aggregate.Field
 import it.unibo.collektive.aggregate.api.Aggregate
 import it.unibo.collektive.alchemist.device.sensors.EnvironmentVariables
-import it.unibo.collektive.examples.chat.gossipGradient
 import it.unibo.collektive.stdlib.spreading.gradientCast
 import kotlin.math.pow
 
 private const val RADIUS = 30.0
 
-fun Aggregate<Int>.inCircleEntrypoint(
-    env: EnvironmentVariables,
-    collektiveDevice: CollektiveDevice<*>
-): Boolean =
+/**
+ * Entry point for the program which computes whether the device is within a circle of a given radius.
+ */
+fun Aggregate<Int>.inCircleEntrypoint(env: EnvironmentVariables, collektiveDevice: CollektiveDevice<*>): Boolean =
     with(collektiveDevice) {
         inCircle(
             center = env["center"],
             p = environment.getPosition(collektiveDevice.node),
-            metric = { distances() }
+            metric = { distances() },
         )
     }
 
-fun Aggregate<Int>.inCircle(
-    center: Boolean,
-    p: Position<*>,
-    metric: () -> Field<Int, Double>
-): Boolean =
-    with(p) {
-        // Broadcast the center position to the whole network
-        val centerPos = gradientCast(
-            source = center,
-            local = this,
-            metric = metric()
-        )
-        distanceToSquared(centerPos) <= RADIUS.pow(2)
-    }
-
+/**
+ * Determines if the current device is within a circle of a specified radius from a center point.
+ */
+fun Aggregate<Int>.inCircle(center: Boolean, p: Position<*>, metric: () -> Field<Int, Double>): Boolean = with(p) {
+    // Broadcast the center position to the whole network
+    val centerPos = gradientCast(
+        source = center,
+        local = this,
+        metric = metric(),
+    )
+    distanceToSquared(centerPos) <= RADIUS.pow(2)
+}
 
 /**
  * @param other the other vector,
@@ -57,5 +53,3 @@ private fun Position<*>.distanceToSquared(other: Position<*>): Double {
     val diff = coordinates.zip(other.coordinates) { c1, c2 -> c1 - c2 }.toDoubleArray()
     return diff.dot(diff)
 }
-
-

--- a/simulation/src/main/kotlin/it/unibo/collektive/examples/inCircle/InCircle.kt
+++ b/simulation/src/main/kotlin/it/unibo/collektive/examples/inCircle/InCircle.kt
@@ -1,0 +1,61 @@
+package it.unibo.collektive.examples.inCircle
+
+import it.unibo.alchemist.collektive.device.CollektiveDevice
+import it.unibo.alchemist.model.Position
+import it.unibo.collektive.aggregate.Field
+import it.unibo.collektive.aggregate.api.Aggregate
+import it.unibo.collektive.alchemist.device.sensors.EnvironmentVariables
+import it.unibo.collektive.examples.chat.gossipGradient
+import it.unibo.collektive.stdlib.spreading.gradientCast
+import kotlin.math.pow
+
+private const val RADIUS = 30.0
+
+fun Aggregate<Int>.inCircleEntrypoint(
+    env: EnvironmentVariables,
+    collektiveDevice: CollektiveDevice<*>
+): Boolean =
+    with(collektiveDevice) {
+        inCircle(
+            center = env["center"],
+            p = environment.getPosition(collektiveDevice.node),
+            metric = { distances() }
+        )
+    }
+
+fun Aggregate<Int>.inCircle(
+    center: Boolean,
+    p: Position<*>,
+    metric: () -> Field<Int, Double>
+): Boolean =
+    with(p) {
+        // Broadcast the center position to the whole network
+        val centerPos = gradientCast(
+            source = center,
+            local = this,
+            metric = metric()
+        )
+        distanceToSquared(centerPos) <= RADIUS.pow(2)
+    }
+
+
+/**
+ * @param other the other vector,
+ * @return the dot product between this and [other].
+ * @throws IllegalArgumentException if the vectors have different sizes
+ */
+private fun DoubleArray.dot(other: DoubleArray): Double {
+    require(size == other.size) { "Vector must have same dimension." }
+    return zip(other) { a, b -> a * b }.sum()
+}
+
+/**
+ * @param other the other position
+ * @return the squared distance between this position and [other]
+ */
+private fun Position<*>.distanceToSquared(other: Position<*>): Double {
+    val diff = coordinates.zip(other.coordinates) { c1, c2 -> c1 - c2 }.toDoubleArray()
+    return diff.dot(diff)
+}
+
+

--- a/simulation/src/main/yaml/inCircle.yml
+++ b/simulation/src/main/yaml/inCircle.yml
@@ -1,0 +1,28 @@
+incarnation: collektive
+
+network-model:
+  type: ConnectWithinDistance
+  parameters: [ 10 ]
+
+_pool: &program
+  - time-distribution: 1
+    type: Event
+    actions:
+      - type: RunCollektiveProgram
+        parameters: [ it.unibo.collektive.examples.inCircle.InCircleKt.inCircleEntrypoint ]
+
+deployments:
+  - type: Grid
+    parameters: [ 0, 0, 200, 200, 5, 5, 1, 1 ]
+    programs:
+      - *program
+    contents:
+      - molecule: center
+        concentration: false
+  - type: Point
+    parameters: [ 100, 100 ]
+    programs:
+      - *program
+    contents:
+      - molecule: center
+        concentration: true


### PR DESCRIPTION
The implementation is based on the `in-circle.proto` demo from the MIT-Proto project.
The goal is to represent a boolean field where each device updates whether it is inside a circle of fixed radius.
Unlike the original example, where the origin was passed as an input to all devices, here the center coordinates are broadcast to all devices, allowing the center to be moved and the field to be recomputed accordingly.

**Related to**:

- Original Proto demo: https://github.com/jakebeal/MIT-Proto/blob/master/proto/demos/in-circle.proto